### PR TITLE
 Use authenticated `/me/clubs` fetch and wire join/leave actions on Club page

### DIFF
--- a/src/pages/Club.tsx
+++ b/src/pages/Club.tsx
@@ -29,8 +29,7 @@ export default function ClubPage() {
 
   // --- membership for current club ---
   const [myRole, setMyRole] = useState<Club["role"] | null>(null);
-  const [checkingMembership, setCheckingMembership] = useState(false);
-  const [membershipUpdating, setMembershipUpdating] = useState(false);
+  const [membershipLoading, setMembershipLoading] = useState(false);
 
   // load club and club events
   useEffect(() => {
@@ -53,12 +52,14 @@ export default function ClubPage() {
         } catch (err) {
           console.warn("API fetch failed", err);
         }
+
         if (!clubData) {
           setError("Club not found");
           return;
         }
+
         // Ensure placeholder logo if missing
-        if (clubData) {
+        if (!clubData.image) {
           clubData.image = placeholderLogo;
         }
 
@@ -69,7 +70,7 @@ export default function ClubPage() {
 
         // Load demo events
         const resEvents = await fetch(`${API_BASE_URL}/events`);
-        // const resEvents = await fetc(`${API_BASE_URL}/events/${clubId}`);
+        // const resEvents = await fetch(`${API_BASE_URL}/events/${clubId}`);
         const jsonEvents = await resEvents.json();
 
         if (!cancelled) {
@@ -104,7 +105,7 @@ export default function ClubPage() {
     }
 
     (async () => {
-      setCheckingMembership(true);
+      setMembershipLoading(true);
       try {
         const res = await fetch(`${API_BASE_URL}/me/clubs`, {
           headers: { Authorization: `Bearer ${token}` },
@@ -119,7 +120,7 @@ export default function ClubPage() {
       } catch {
         if (!cancelled) setMyRole(null);
       } finally {
-        if (!cancelled) setCheckingMembership(false);
+        if (!cancelled) setMembershipLoading(false);
       }
     })();
 
@@ -137,7 +138,7 @@ export default function ClubPage() {
   const dateOnlyGTE = (aIso: string, bDate: Date) =>
     startOfDay(new Date(aIso)).getTime() >= startOfDay(bDate).getTime();
 
-  // Partition by END DAY: if event ends today or later → Upcoming
+  // Partition by END DAY: if event ends today or later -> Upcoming
   const { upcoming, previous } = useMemo(() => {
     const now = new Date();
     const up: Event[] = [];
@@ -183,19 +184,16 @@ export default function ClubPage() {
     );
   }
 
-  // Map membership → FeaturedClubCard.action
-  // during membership check or mutation we hide the button (`none`) to avoid flicker
-  const membershipBusy = checkingMembership || membershipUpdating;
-
+  // Map membership -> FeaturedClubCard.action
+  // during membership check or mutation we hide the button ("none") to avoid flicker
   const action: "none" | "join" | "leave" =
-    !auth.signedIn || membershipBusy || myRole === "owner"
+    !auth.signedIn || membershipLoading || myRole === "owner"
       ? "none"
       : myRole === "member" || myRole === "eboard"
       ? "leave"
       : "join";
 
   // ---- Join / leave handlers ----
-  // helper for reading return first
   async function readApiErrorMessage(res: Response): Promise<string> {
     let raw = "";
     try {
@@ -213,18 +211,16 @@ export default function ClubPage() {
         if (typeof obj.message === "string") return obj.message;
       }
     } catch {
-      console.warn("Error in parsing API error")
+      console.warn("Error in parsing API error");
     }
 
     return raw || "<empty response body>";
   }
 
-  // join and leave functions
   const handleJoin = async () => {
     if (!clubId) return;
 
     if (!auth.signedIn) {
-      // If not signed in, send them through Cognito
       auth.signIn();
       return;
     }
@@ -235,7 +231,7 @@ export default function ClubPage() {
       return;
     }
 
-    setMembershipUpdating(true);
+    setMembershipLoading(true);
     try {
       const res = await fetch(`${API_BASE_URL}/clubs/${clubId}/members/me`, {
         method: "POST",
@@ -250,12 +246,11 @@ export default function ClubPage() {
         return;
       }
 
-      // Optimistically update local role
       setMyRole("member");
     } catch (err) {
       console.error("Error joining club", err);
     } finally {
-      setMembershipUpdating(false);
+      setMembershipLoading(false);
     }
   };
 
@@ -273,7 +268,7 @@ export default function ClubPage() {
       return;
     }
 
-    setMembershipUpdating(true);
+    setMembershipLoading(true);
     try {
       const res = await fetch(`${API_BASE_URL}/clubs/${clubId}/members/me`, {
         method: "DELETE",
@@ -288,15 +283,13 @@ export default function ClubPage() {
         return;
       }
 
-      // Optimistically clear role
       setMyRole(null);
     } catch (err) {
       console.error("Error leaving club", err);
     } finally {
-      setMembershipUpdating(false);
+      setMembershipLoading(false);
     }
   };
-
 
   // === Main page ===
   return (

--- a/src/pages/Club.tsx
+++ b/src/pages/Club.tsx
@@ -30,6 +30,7 @@ export default function ClubPage() {
   // --- membership for current club ---
   const [myRole, setMyRole] = useState<Club["role"] | null>(null);
   const [checkingMembership, setCheckingMembership] = useState(false);
+  const [membershipUpdating, setMembershipUpdating] = useState(false);
 
   // load club and club events
   useEffect(() => {
@@ -183,13 +184,94 @@ export default function ClubPage() {
   }
 
   // Map membership → FeaturedClubCard.action
-  // during membership check we hide the button (`none`) to avoid flicker
+  // during membership check or mutation we hide the button (`none`) to avoid flicker
+  const membershipBusy = checkingMembership || membershipUpdating;
+
   const action: "none" | "join" | "leave" =
-    !auth.signedIn || checkingMembership || myRole === "owner"
+    !auth.signedIn || membershipBusy || myRole === "owner"
       ? "none"
       : myRole === "member" || myRole === "eboard"
       ? "leave"
       : "join";
+
+  // ---- Join / leave handlers ----
+  const handleJoin = async () => {
+    if (!clubId) return;
+
+    if (!auth.signedIn) {
+      // If not signed in, send them through Cognito
+      auth.signIn();
+      return;
+    }
+
+    const token = auth.getAccessToken();
+    if (!token) {
+      console.warn("No access token; cannot join club.");
+      return;
+    }
+
+    setMembershipUpdating(true);
+    try {
+      const res = await fetch(`${API_BASE_URL}/clubs/${clubId}/members/me`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        console.error("Failed to join club", res.status, text);
+        return;
+      }
+
+      // Optimistically update local role
+      setMyRole("member");
+    } catch (err) {
+      console.error("Error joining club", err);
+    } finally {
+      setMembershipUpdating(false);
+    }
+  };
+
+  const handleLeave = async () => {
+    if (!clubId) return;
+
+    if (!auth.signedIn) {
+      auth.signIn();
+      return;
+    }
+
+    const token = auth.getAccessToken();
+    if (!token) {
+      console.warn("No access token; cannot leave club.");
+      return;
+    }
+
+    setMembershipUpdating(true);
+    try {
+      const res = await fetch(`${API_BASE_URL}/clubs/${clubId}/members/me`, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        console.error("Failed to leave club", res.status, text);
+        return;
+      }
+
+      // Optimistically clear role
+      setMyRole(null);
+    } catch (err) {
+      console.error("Error leaving club", err);
+    } finally {
+      setMembershipUpdating(false);
+    }
+  };
+
 
   // === Main page ===
   return (
@@ -207,6 +289,8 @@ export default function ClubPage() {
             <FeaturedClubCard
               club={{ ...club, role: (myRole ?? club.role) as Club["role"] }}
               action={action}
+              onJoinClick={handleJoin}
+              onLeaveClick={handleLeave}
             />
           ) : (
             <div style={{ height: 200 }} />

--- a/src/pages/Club.tsx
+++ b/src/pages/Club.tsx
@@ -195,6 +195,31 @@ export default function ClubPage() {
       : "join";
 
   // ---- Join / leave handlers ----
+  // helper for reading return first
+  async function readApiErrorMessage(res: Response): Promise<string> {
+    let raw = "";
+    try {
+      raw = await res.text();
+    } catch (err) {
+      console.warn("Failed to read response body", err);
+      return "<failed to read response body>";
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed && typeof parsed === "object") {
+        const obj = parsed as Record<string, unknown>;
+        if (typeof obj.error === "string") return obj.error;
+        if (typeof obj.message === "string") return obj.message;
+      }
+    } catch {
+      console.warn("Error in parsing API error")
+    }
+
+    return raw || "<empty response body>";
+  }
+
+  // join and leave functions
   const handleJoin = async () => {
     if (!clubId) return;
 
@@ -220,8 +245,8 @@ export default function ClubPage() {
       });
 
       if (!res.ok) {
-        const text = await res.text().catch(() => "");
-        console.error("Failed to join club", res.status, text);
+        const msg = await readApiErrorMessage(res);
+        console.error("Failed to join club", res.status, msg);
         return;
       }
 
@@ -258,8 +283,8 @@ export default function ClubPage() {
       });
 
       if (!res.ok) {
-        const text = await res.text().catch(() => "");
-        console.error("Failed to leave club", res.status, text);
+        const msg = await readApiErrorMessage(res);
+        console.error("Failed to leave club", res.status, msg);
         return;
       }
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -67,12 +67,30 @@ export default function Home() {
     };
   }, [])
 
-  // Fetch clubs for MyClubs component
+    // Fetch clubs for MyClubs component
   useEffect(() => {
     let cancelled = false;
+
+    // If not signed in or no access token, clear clubs and stop
+    if (!authInfo.signedIn) {
+      setClubs([]);
+      setLoadingClubs(false);
+      return;
+    }
+
+    const token = authInfo.getAccessToken();
+    if (!token) {
+      setClubs([]);
+      setLoadingClubs(false);
+      return;
+    }
+
     (async () => {
+      setLoadingClubs(true);
       try {
-        const res = await fetch("/api/me/clubs");
+        const res = await fetch(`${API_BASE_URL}/me/clubs`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
         const json = await res.json();
         if (cancelled) return;
 
@@ -89,7 +107,8 @@ export default function Home() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [authInfo.signedIn, authInfo.accessToken]);
+
 
   const handleClubClick = (club: any) => {
     navigate(`/club/${club.id}`);
@@ -143,7 +162,14 @@ export default function Home() {
         {/* Right rail becomes its own row on small; stacks on md+ */}
         <Grid.Col span={{ base: 12, md: 3, lg: 3 }}>
           <SimpleGrid cols={{ base: 2, md: 1 }} spacing="1.25rem">
-            <MyClubs clubs={clubs} loading={loadingClubs} onClubClick={handleClubClick} onDirectoryClick={handleDirectoryClick} onCreateClub={handleCreateClub} isSignedIn={authInfo?.signedIn} />
+            <MyClubs 
+              clubs={clubs} 
+              loading={loadingClubs} 
+              onClubClick={handleClubClick} 
+              onDirectoryClick={handleDirectoryClick} 
+              onCreateClub={handleCreateClub} 
+              isSignedIn={authInfo?.signedIn} 
+            />
             <ToClubDirectory />
           </SimpleGrid>
         </Grid.Col>


### PR DESCRIPTION
## Description

Note: kyle ai generated this message

This PR updates the Home page to use an authenticated `/me/clubs` fetch and wires the Club page’s CTA so users can join or leave a club directly from the club detail view.

## Changes

### Home.tsx

- Use `auth.ts` / `useAuthInfo` in `Home.tsx` to derive the current auth state.
- Call the `/me/clubs` endpoint with an `Authorization: Bearer <accessToken>` header instead of an unauthenticated request.
- Short-circuit the effect when the user is signed out or there is no access token, returning an empty clubs list and avoiding unnecessary failed requests.
- Preserve the existing parsing logic for the `/me/clubs` response when setting `clubs` and `loadingClubs`.

### Club.tsx

- Add membership state and UI flags:
  - `myRole` (current user’s role in the club)  
  - `checkingMembership` (initial `/me/clubs` check)  
  - `membershipUpdating` (join/leave in flight)
- Derive an `action: "none" | "join" | "leave"` for `FeaturedClubCard` based on:
  - Current auth state
  - Membership status (`myRole`)
  - Loading flags (`checkingMembership` / `membershipUpdating`)
- Implement `handleJoin`:
  - Guard against missing `clubId` or missing access token.
  - Call `POST /clubs/{clubId}/members/me` with `Authorization: Bearer <accessToken>`.
  - On success, optimistically set `myRole` to `"member"` so the UI flips immediately to a leave state.
- Implement `handleLeave`:
  - Guard against missing `clubId` or missing access token.
  - Call `DELETE /clubs/{clubId}/members/me` with `Authorization: Bearer <accessToken>`.
  - On success, clear `myRole` so the UI flips back to a join state.
- Hide the join/leave button while membership is loading or a mutation is in progress to avoid flicker and double-submits.
- Pass `onJoinClick={handleJoin}` and `onLeaveClick={handleLeave}` into `FeaturedClubCard`.

## Testing

### Home

- Signed in, verified that **My Clubs** loads correctly with the expected club list using the authenticated `/me/clubs` request.
- Signed out, verified that no authenticated `/me/clubs` request is sent and the Home page renders without errors (empty “My Clubs” list).

### Club

- Signed in on a club page where the user is **not** a member:
  - Clicked **Join**, saw `POST /clubs/{id}/members/me` with an `Authorization` header succeed and the button change to **Leave**.
- Signed in on a club page where the user **is** a member:
  - Clicked **Leave**, saw `DELETE /clubs/{id}/members/me` succeed and the button change back to **Join**.
- Verified that the join/leave button is hidden while membership is still being checked or a join/leave request is in progress to prevent double-clicks.